### PR TITLE
Minor Updates: fixed link and number of examples

### DIFF
--- a/docs/specification/tutorial/examples.md
+++ b/docs/specification/tutorial/examples.md
@@ -322,7 +322,7 @@ packages = ["requests", "pyodide-http"]
                     </div>
             <p>11 Recipes for Success with the BTAA Geoportal API</p>
             <p>Download the full runnable Python script containing all these examples, or run them directly in your browser below!</p>
-            <p><a href="btaa_api_examples.py" class="btn" download>Download Python Script</a></p>
+            <p><a href="../btaa_api_examples.py" class="btn" download>Download Python Script</a></p>
             <p style="margin-top: 30px; color: #718096;">Use the navigation buttons below or arrow keys to move between examples.</p>
         </div>
 

--- a/docs/specification/tutorial/presentation.md
+++ b/docs/specification/tutorial/presentation.md
@@ -245,7 +245,7 @@ html:fullscreen body.tutorial-fullscreen .controls {
 
     <div class="slide">
         <h2>5. Practical Application</h2>
-        <p>We have prepared 10 practical "recipes" or examples to demonstrate common tasks, from basic searching
+        <p>We have prepared 11 practical "recipes" or examples to demonstrate common tasks, from basic searching
             to
             extracting IIIF manifests for map viewers.</p>
         <a href="../examples" class="md-button">View Code Examples</a>


### PR DESCRIPTION
The link to the python script in examples.md works in dev, but not after build so I updated it to be a relative link up one directory. 

Secondly, there are 11 examples but an earlier slide said only 10 so I updated it to say 11.

Very minor changes, but I hope they help!